### PR TITLE
Change Juiser Property Key

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,8 +2,7 @@ server:
   use-forward-headers: true
 
 juiser:
-  user:
-    header:
-      jwt:
-        key:
-          resource: classpath:rsatest.pub.pem
+  header:
+    jwt:
+      key:
+        resource: classpath:rsatest.pub.pem


### PR DESCRIPTION
Commit [df991ad](https://github.com/juiser/juiser/commit/df991adaed56696de26d5ddac238771ed041258a) changed the JWT property key from

`juiser.user.header.jwt.key.resource`

to

`juiser.header.jwt.key.resource`

This PR updates this example project to reflect that change.