### PR TITLE
Provide Default Security Config

### DIFF
--- a/src/main/java/org/juiser/examples/origin/SecurityConfig.java
+++ b/src/main/java/org/juiser/examples/origin/SecurityConfig.java
@@ -9,5 +9,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests().anyRequest().fullyAuthenticated();
     }
 }


### PR DESCRIPTION
The current `SecurityConfig` is an empty override of the `configure` method from `WebSecurityConfigurerAdapter`.  This actually exposes all endpoints.

This PR provides a standard security configuration that secures all endpoints.